### PR TITLE
append kifu saving feature

### DIFF
--- a/public/appmain.js
+++ b/public/appmain.js
@@ -235,6 +235,9 @@ var bindScreenEvents = function(client){
     //if(this.checked) {  }
     drawGameField(client.roomInfo, client.playerNo);
   });
+  
+  // 棋譜生成
+  $("#btn-save-kifu").click(saveKifu);
 };
 
 var loadImg = function(){
@@ -616,7 +619,7 @@ var updateRoomInfo = function(room, isPublic){
   $("#room-name").html("room #" + room.id.padZero(2));
   $("#room-header-name").html("ルーム #" + room.id.padZero(2));
 
-  //ラウンドの合間（終了〜READY押すまで）は盤面の描画しない
+  //ラウンドの合間（終了?READY押すまで）は盤面の描画しない
   //つまり、最初にRoomに入った時と、ラウンドの最中のみ描画
   if( isRoomInit || room.round){
       drawGameField(room, client.playerNo);
@@ -1083,4 +1086,29 @@ var drawOfflineIcon = function(ctx){
   ctx.beginPath();
   ctx.arc(10, 10, 8, 0, Math.PI * 2.0, true);
   ctx.fill();
+};
+
+var saveKifu = function() {
+  var content = client.roomInfo.kifuText;
+  var bom = new Uint8Array([0xEF, 0xBB, 0xBF]);
+  var blob = new Blob([ bom, content ], { "type" : "text/plain" });
+
+  var date = new Date();
+  var filename = "goita_kifu_" + date.getFullYear() + "-" + date.getMonth() + "-" + date.getDate() + "-" + date.getHours() + "-" + date.getMinutes() + "-" + date.getSeconds() + ".yaml";
+
+  if (window.navigator.msSaveBlob) { 
+    window.navigator.msSaveBlob(blob, filename); 
+
+    // msSaveOrOpenBlobの場合はファイルを保存せずに開ける
+    window.navigator.msSaveOrOpenBlob(blob, filename); 
+  } else {
+    var a = document.createElement("a");
+    document.body.appendChild(a);
+    a.href = URL.createObjectURL(blob);
+    a.target = '_blank';
+    a.download = filename;
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL();
+  }
 };

--- a/public/index.html
+++ b/public/index.html
@@ -126,6 +126,9 @@
                   class="ui-btn ui-icon-star ui-btn-icon-left ui-btn-b">５しの処理を選択</a>
             </div>
           </fieldset>
+          <fieldset class="ui-grid-b">
+            <div class="ui-block-a"><button id="btn-save-kifu">棋譜を保存</button></div>
+          </fieldset>
         </div>
         
       </div><!--/main-->


### PR DESCRIPTION
早速ありがとうございます。

ラウンドの棋譜保存機能を追加しました。

保存ボタンは、「なし」の下に置きましたが、気に入らなければ適当に動かして下さい。
iPhone で使うことを考えたらここかなぁと思っただけですので。

Firefox / Chrome / Edge / iPhone で動作確認しています。

RoomInfo に kifu と kifuText というプロパティを追加して、
play / finishRound で kifu にプレイ記録を足して言っています。

kifu は [ ["プレイヤ番号", "駒1", "駒2"], ... ] という形式で記憶しています。

棋譜テキストは finishRound で生成しています。
得点加算前に生成しています。

実際の生成は makeKifuText 関数で行っています。

棋譜のフォーマットですが、勝手ながら YAML にさせて頂きました。JSON は個人的にちょっと読みにくいので…複数ラウンドの記録を仮定したフォーマットにしたので、後々、ゲーム全体を記録するように書き換えたいと思っております。


--- 棋譜フォーマットの簡易説明
version: 1.0
p0: "プレーヤー１の名前"
p1: "プレーヤー２の名前"
p2: "プレーヤー３の名前"
p3: "プレーヤー４の名前"
log:
 - hand: # ここが配列になっているので、複数ゲームの記録が可能です。
     p0: "手駒８枚"
     p1: "手駒８枚"
     p2: "手駒８枚"
     p3: "手駒８枚"
   uchidashi: 打ち出しプレーヤ番号（0-3）
   score: [P1P3のスコア,P2P4のスコア]
   game:
    - ["1","馬","金"] # P1 が 馬を防御に、金を攻めに
    - ["0","金","飛"] # 以下同様、配列で終わるまで
    - ["0","し","角"]
    - ["1","角","銀"]
    - ["0","銀","し"]
    - ["1","し","銀"]
    - ["3","銀","し"]
    - ["2","し","飛"]
    - ["3","王","し"]
    - ["2","し","金"]
    - ["0","王","馬"]